### PR TITLE
[t133316] Add buttons to create/assign Lots also in stock move wizard

### DIFF
--- a/setup/stock_picking_product_generate_sequence/odoo/addons/stock_picking_product_generate_sequence
+++ b/setup/stock_picking_product_generate_sequence/odoo/addons/stock_picking_product_generate_sequence
@@ -1,0 +1,1 @@
+../../../../stock_picking_product_generate_sequence

--- a/setup/stock_picking_product_generate_sequence/setup.py
+++ b/setup/stock_picking_product_generate_sequence/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_picking_product_generate_sequence/__init__.py
+++ b/stock_picking_product_generate_sequence/__init__.py
@@ -1,0 +1,7 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://braintec.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+from . import models

--- a/stock_picking_product_generate_sequence/__manifest__.py
+++ b/stock_picking_product_generate_sequence/__manifest__.py
@@ -1,0 +1,27 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://braintec.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+{
+    "name": "Stock Picking Product Generate sequence",
+    "version": "15.0.1.0.0",
+    "summary": "Add an automated sequence in product of stock picking",
+    "category": "Inventory",
+    "author": "brain-tec AG, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/stock-logistics-workflow",
+    "depends": [
+        "product",
+        "stock",
+    ],
+    "license": "AGPL-3",
+    "data": [
+        "views/product_template_views.xml",
+        "views/stock_move_line_views.xml",
+        "data/stock_picking_product_sequence.xml",
+    ],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+}

--- a/stock_picking_product_generate_sequence/data/stock_picking_product_sequence.xml
+++ b/stock_picking_product_generate_sequence/data/stock_picking_product_sequence.xml
@@ -1,0 +1,11 @@
+<odoo noupdate="1">
+    <record id="seq_stock_picking_product" model="ir.sequence">
+        <field name="name">Stock Picking Product</field>
+        <field name="code">stock.picking.product</field>
+        <field name="prefix">SPP/</field>
+        <field name="padding">8</field>
+        <field name="number_next">1</field>
+        <field name="number_increment">1</field>
+        <field name="company_id" eval="False" />
+    </record>
+</odoo>

--- a/stock_picking_product_generate_sequence/models/__init__.py
+++ b/stock_picking_product_generate_sequence/models/__init__.py
@@ -1,0 +1,8 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://braintec.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+from . import product_template
+from . import stock_move_line

--- a/stock_picking_product_generate_sequence/models/__init__.py
+++ b/stock_picking_product_generate_sequence/models/__init__.py
@@ -6,3 +6,4 @@
 ##############################################################################
 from . import product_template
 from . import stock_move_line
+from . import stock_move

--- a/stock_picking_product_generate_sequence/models/product_template.py
+++ b/stock_picking_product_generate_sequence/models/product_template.py
@@ -1,0 +1,58 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://braintec.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+from re import match as regex_match, split as regex_split
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    serial_lot = fields.Char(
+        string="Sequence Product",
+        help="Create a sequence for product. Remember sequence contains one character "
+        "block and one numeric block. For the numeric part of the sequence, 0 must be "
+        "used to create the padding. E.g.: TEST/00000 (padding is 5)",
+    )
+
+    @api.onchange("serial_lot")
+    def _onchange_serial_lot(self):
+        pattern = "(?:^\\D{1,}\\d{1,}$)"
+        if self.serial_lot:
+            split_sequence_product = regex_split(r"(\d+)", self.serial_lot)
+            global_sequence = self.env.ref(
+                "stock_picking_product_generate_sequence.seq_stock_picking_product"
+            )
+            if (
+                split_sequence_product[0].casefold()
+                == str(global_sequence.prefix).casefold()
+            ):
+                raise UserError(
+                    _("The prefix sequence is the same as for the standard product")
+                )
+            if regex_match(pattern, self.serial_lot) is None:
+                raise UserError(_("The sequence format is not correct"))
+
+    @api.constrains("serial_lot")
+    def _check_serial_lot(self):
+        pattern = "(?:^\\D{1,}\\d{1,}$)"
+        global_sequence = self.env.ref(
+            "stock_picking_product_generate_sequence.seq_stock_picking_product"
+        )
+        for serial in self:
+            if serial.serial_lot:
+                split_serial_product = regex_split(r"(\d+)", serial.serial_lot)
+                if (
+                    split_serial_product[0].casefold()
+                    == str(global_sequence.prefix).casefold()
+                ):
+                    raise UserError(
+                        _("The prefix sequence is the same as for the standard product")
+                    )
+                if regex_match(pattern, serial.serial_lot) is None:
+                    raise UserError(_("The sequence format is not correct"))

--- a/stock_picking_product_generate_sequence/models/stock_move.py
+++ b/stock_picking_product_generate_sequence/models/stock_move.py
@@ -1,0 +1,25 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://braintec.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+from odoo import models, fields
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    show_lots_text = fields.Boolean(compute="_compute_show_lots_text")
+
+    def _compute_show_lots_text(self):
+        group_production_lot_enabled = self.user_has_groups('stock.group_production_lot')
+        for move in self:
+            picking = move.picking_id
+            if not picking.move_line_ids and not picking.picking_type_id.use_create_lots:
+                move.show_lots_text = False
+            elif group_production_lot_enabled and picking.picking_type_id.use_create_lots \
+                    and not picking.picking_type_id.use_existing_lots and picking.state != 'done':
+                move.show_lots_text = True
+            else:
+                move.show_lots_text = False

--- a/stock_picking_product_generate_sequence/models/stock_move_line.py
+++ b/stock_picking_product_generate_sequence/models/stock_move_line.py
@@ -23,6 +23,22 @@ class StockMoveLine(models.Model):
                 or self.env["ir.sequence"].next_by_code("stock.picking.product"),
             }
         )
+        if self.env.context.get('keep_open_wizard'):
+            return self.move_id.action_show_details()
+
+    def action_copy_product_serial(self):
+        is_line_after = False
+        for move_line in self.move_id.move_line_ids:
+            if move_line == self:
+                is_line_after = True
+            elif is_line_after:
+                if not move_line.lot_id:
+                    move_line.lot_id = self.lot_id
+                else:
+                    # when one of the next lines has already a lot, we stop there
+                    break
+        if self.env.context.get('keep_open_wizard'):
+            return self.move_id.action_show_details()
 
     @api.model
     def _get_next_serial(self, company, product):

--- a/stock_picking_product_generate_sequence/models/stock_move_line.py
+++ b/stock_picking_product_generate_sequence/models/stock_move_line.py
@@ -1,0 +1,56 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://braintec.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+from re import split as regex_split
+
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def action_generate_product_serial(self):
+        self.ensure_one()
+        self.lot_id = self.env["stock.production.lot"].create(
+            {
+                "product_id": self.product_id.id,
+                "company_id": self.company_id.id,
+                "name": self._get_next_serial(self.company_id, self.product_id)
+                or self.env["ir.sequence"].next_by_code("stock.picking.product"),
+            }
+        )
+
+    @api.model
+    def _get_next_serial(self, company, product):
+        sequence = product.product_tmpl_id.serial_lot
+        if sequence:
+            splitted = regex_split(r"(\d+)", sequence)
+            prefix = splitted[0]
+            initial_number = int(splitted[1])
+            padding = len(splitted[1])
+            last_serial = self.env["stock.production.lot"].search(
+                [
+                    ("company_id", "=", company.id),
+                    ("product_id", "=", product.id),
+                    ("name", "=ilike", "%s%%" % prefix),
+                ],
+                limit=1,
+                order="id DESC",
+            )
+
+            if last_serial:
+                last_serial_splitted = regex_split(r"(\d+)", last_serial.name)
+                if last_serial_splitted[0] and last_serial_splitted[1]:
+                    last_serial_prefix = last_serial_splitted[0]
+                    last_serial_number = int(last_serial_splitted[1])
+                    return "".join(
+                        [last_serial_prefix, str(last_serial_number + 1).zfill(padding)]
+                    )
+                else:
+                    raise UserError(_("The sequence format is not correct"))
+            return "".join([prefix, str(initial_number + 1).zfill(padding)])
+        return False

--- a/stock_picking_product_generate_sequence/readme/CONTRIBUTORS.rst
+++ b/stock_picking_product_generate_sequence/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* David Montull Guasch <david.montull@bt-group.com> (https://braintec.com)

--- a/stock_picking_product_generate_sequence/readme/DESCRIPTION.rst
+++ b/stock_picking_product_generate_sequence/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module adds the possibility to generate the batch sequence by button.
+This feature is only for the entry of goods.
+The sequence value is taken from the product template field and if it does not exist,
+the value of a global sequence is used.

--- a/stock_picking_product_generate_sequence/views/product_template_views.xml
+++ b/stock_picking_product_generate_sequence/views/product_template_views.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.inherit.view.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <group name="packaging" position="before">
+                <group name="serial">
+                    <field name="serial_lot" />
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/stock_picking_product_generate_sequence/views/stock_move_line_views.xml
+++ b/stock_picking_product_generate_sequence/views/stock_move_line_views.xml
@@ -38,4 +38,80 @@
             </field>
         </field>
     </record>
+
+    <record id="view_stock_move_nosuggest_operations" model="ir.ui.view">
+        <field name="name">stock.move.lot.operations.nosuggest.form</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_stock_move_nosuggest_operations"/>
+        <field name="arch" type="xml">
+            <field name="move_line_nosuggest_ids" position="before">
+                <field name="show_lots_text" invisible="True" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_stock_move_line_operation_tree" model="ir.ui.view">
+        <field name="name">stock.move.line.lot.operations.tree</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree"/>
+        <field name="arch" type="xml">
+            <field name="lot_id" position="after">
+                <field name="lots_visible" invisible="1" />
+                <button
+                    name="action_generate_product_serial"
+                    type="object"
+                    class="btn btn-primary fa fa-plus-square-o"
+                    title="Creates a new serial/lot number"
+                    groups="stock.group_production_lot"
+                    context="{'keep_open_wizard': True}"
+                    attrs="{
+                        'column_invisible': [
+                            ('parent.show_lots_text', '=', True)
+                        ],
+                        'invisible': [
+                            '|',
+                            '|',
+                            '|',
+                            ('lots_visible', '=', False),
+                            ('lot_id', '!=', False),
+                            ('picking_code', '!=', 'incoming'),
+                            ('state', 'not in', [
+                                'draft',
+                                'assigned',
+                                'waiting',
+                                'partially_available',
+                            ])
+                        ]
+                     }"
+                />
+                <button
+                    name="action_copy_product_serial"
+                    type="object"
+                    class="btn btn-primary fa fa-level-down"
+                    title="Creates a new serial/lot number"
+                    groups="stock.group_production_lot"
+                    context="{'keep_open_wizard': True}"
+                    attrs="{
+                        'column_invisible': [
+                            ('parent.show_lots_text', '=', True)
+                        ],
+                        'invisible': [
+                            '|',
+                            '|',
+                            '|',
+                            ('lots_visible', '=', False),
+                            ('lot_id', '=', False),
+                            ('picking_code', '!=', 'incoming'),
+                            ('state', 'not in', [
+                                'draft',
+                                'assigned',
+                                'waiting',
+                                'partially_available',
+                            ])
+                        ]
+                     }"
+                />
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/stock_picking_product_generate_sequence/views/stock_move_line_views.xml
+++ b/stock_picking_product_generate_sequence/views/stock_move_line_views.xml
@@ -1,0 +1,41 @@
+<odoo>
+    <record id="view_stock_move_line_detailed_operation_tree" model="ir.ui.view">
+        <field name="name">stock.move.line.view.tree</field>
+        <field name="model">stock.move.line</field>
+        <field
+            name="inherit_id"
+            ref="stock.view_stock_move_line_detailed_operation_tree"
+        />
+        <field name="arch" type="xml">
+            <field name="lot_id" position="after">
+                <field name="picking_code" invisible="1" />
+                <button
+                    name="action_generate_product_serial"
+                    type="object"
+                    class="btn btn-primary fa fa-plus-square-o"
+                    title="Creates a new serial/lot number"
+                    groups="stock.group_production_lot"
+                    attrs="{
+                        'column_invisible': [
+                            ('parent.show_lots_text', '=', True)
+                            ],
+                        'invisible': [
+                            '|',
+                            '|',
+                            '|',
+                            ('lots_visible', '=', False),
+                            ('lot_id', '!=', False),
+                            ('picking_code', '!=', 'incoming'),
+                            ('state', 'not in', [
+                                'draft',
+                                'assigned',
+                                'waiting',
+                                'partially_available',
+                                ])
+                            ]
+                         }"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When the picking operation type is configure to not show the Detailed Operations tab, a button appears in the stock move lines to open a wizard that allows you modified the stock.move.line records.
This is the place where now, after applying this PR we will get two different buttons, one for creating a sequential Lot for the move line, and other to help assign it to other move lines below.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec.com/web#view_type=form&model=project.task&id=133316">[t133316] [t411] Sequential Batch Number (Button for Next Lot Number in a Sequence)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>stock_picking_product_generate_sequence</td><td>.py, .rst, .xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->