### PR TITLE
[t133316] Add show_lots_text to operations stock move wizard

### DIFF
--- a/stock_picking_product_generate_sequence/views/stock_move_line_views.xml
+++ b/stock_picking_product_generate_sequence/views/stock_move_line_views.xml
@@ -50,6 +50,17 @@
         </field>
     </record>
 
+    <record id="view_stock_move_operations" model="ir.ui.view">
+        <field name="name">stock.move.lot.operations.form</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_stock_move_operations"/>
+        <field name="arch" type="xml">
+            <field name="product_uom_category_id" position="after">
+                <field name="show_lots_text" invisible="True" />
+            </field>
+        </field>
+    </record>
+
     <record id="view_stock_move_line_operation_tree" model="ir.ui.view">
         <field name="name">stock.move.line.lot.operations.tree</field>
         <field name="model">stock.move.line</field>


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec.com/web#view_type=form&model=project.task&id=133316">[t133316] [t411] Sequential Batch Number (Button for Next Lot Number in a Sequence)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>stock_picking_product_generate_sequence</td><td>.xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->